### PR TITLE
Add CPU/n_threads argument to CWL

### DIFF
--- a/cwl/README.md
+++ b/cwl/README.md
@@ -1,0 +1,23 @@
+# Deployment
+
+To deploy the apps on SBG, push them to the correct project.
+
+## Devel project
+
+Push to the devel project to test the app before release.
+
+```
+sbpack bdc amstilp/ld-compute-devel/ld-index cwl/ld-index.cwl
+sbpack bdc amstilp/ld-compute-devel/ld-pair cwl/ld-pair.cwl
+sbpack bdc amstilp/ld-compute-devel/ld-set cwl/ld-set.cwl
+```
+
+## Commit project
+
+Push to the commit project to make a new release.
+
+```
+sbpack bdc smgogarten/uw-gac-commit/ld-index cwl/ld-index.cwl
+sbpack bdc smgogarten/uw-gac-commit/ld-pair cwl/ld-pair.cwl
+sbpack bdc smgogarten/uw-gac-commit/ld-set cwl/ld-set.cwl
+```

--- a/cwl/ld-index.cwl
+++ b/cwl/ld-index.cwl
@@ -92,6 +92,17 @@ inputs:
     shellQuote: false
   label: Sample include file
   doc: File containing the sample ids on which to calculate LD.
+- id: cpu
+  label: cpu
+  doc: Number of CPUs to use.
+  type: int?
+  default: 4
+  inputBinding:
+    prefix: --n_threads
+    position: 20
+    shellQuote: false
+  sbg:category: Input Options
+  sbg:toolDefaultValue: '4'
 
 outputs:
 - id: ld

--- a/cwl/ld-pair.cwl
+++ b/cwl/ld-pair.cwl
@@ -91,6 +91,17 @@ inputs:
     shellQuote: false
   label: Sample include file
   doc: File containing the sample ids on which to calculate LD.
+- id: cpu
+  label: cpu
+  doc: Number of CPUs to use.
+  type: int?
+  default: 4
+  inputBinding:
+    prefix: --n_threads
+    position: 20
+    shellQuote: false
+  sbg:category: Input Options
+  sbg:toolDefaultValue: '4'
 
 outputs:
 - id: ld

--- a/cwl/ld-set.cwl
+++ b/cwl/ld-set.cwl
@@ -84,6 +84,17 @@ inputs:
     shellQuote: false
   label: Output file prefix.
   doc: Output file prefix. Will be appended to "_ld.rds".
+- id: cpu
+  label: cpu
+  doc: Number of CPUs to use.
+  type: int?
+  default: 4
+  inputBinding:
+    prefix: --n_threads
+    position: 20
+    shellQuote: false
+  sbg:category: Input Options
+  sbg:toolDefaultValue: '4'
 
 outputs:
 - id: ld


### PR DESCRIPTION
Allow the user to specify the number of CPUs to use in the CWL for all apps.